### PR TITLE
fix: fdcan-gui.py  

### DIFF
--- a/software/fdcan-gui/fdcan-gui.py
+++ b/software/fdcan-gui/fdcan-gui.py
@@ -261,10 +261,14 @@ class MainWindow(QMainWindow):
           self.ui.text_device_info.appendPlainText(self.device_info[index])    
           self.ui.text_device_info.appendPlainText("    ")
 
+          resp.boot.name_str = resp.boot.name_str.replace('\x00', '')
           self.ui.text_device_info.appendPlainText(resp.boot.name_str)
+          resp.boot.version_str = resp.boot.version_str.replace('\x00', '')
           self.ui.text_device_info.appendPlainText("    " + resp.boot.version_str)
 
+          resp.firm.name_str = resp.firm.name_str.replace('\x00', '')
           self.ui.text_device_info.appendPlainText(resp.firm.name_str)
+          resp.firm.version_str = resp.firm.version_str.replace('\x00', '')
           self.ui.text_device_info.appendPlainText("    " + resp.firm.version_str)     
           is_connected = True
           break


### PR DESCRIPTION
ValueError: embedded null character 에러가 Ubuntu, Windows 에서 반환 되는 것을 확인했습니다. 문자열을 불러오는 과정에서 Null 값이 포함되어 있어 발생하는 문제인 것으로 파악 되어 Null을 제거하는 코드를 추가해 주었습니다. 

